### PR TITLE
Improve PatchPanel ComputeValues on changes in the UI

### DIFF
--- a/teemip-cable-mgmt/datamodel.teemip-cable-mgmt.xml
+++ b/teemip-cable-mgmt/datamodel.teemip-cable-mgmt.xml
@@ -2338,11 +2338,17 @@
           <sql>free_sockets</sql>
           <default_value/>
           <is_null_allowed>true</is_null_allowed>
+          <dependencies>
+              <attribute id="capacity" />
+          </dependencies>
         </field>
         <field id="ready_sockets" xsi:type="AttributeInteger">
           <sql>ready_sockets</sql>
           <default_value/>
           <is_null_allowed>true</is_null_allowed>
+          <dependencies>
+              <attribute id="capacity" />
+          </dependencies>
         </field>
         <field id="networksockets_list" xsi:type="AttributeLinkedSet">
           <linked_class>NetworkSocket</linked_class>
@@ -2394,6 +2400,11 @@
         <event_listener id="OnPatchPanelComputeValuesRequestedByCableMgmt">
           <event>EVENT_DB_COMPUTE_VALUES</event>
           <callback>OnPatchPanelComputeValuesRequestedByCableMgmt</callback>
+          <rank>10</rank>
+        </event_listener>
+        <event_listener id="OnPatchPanelSetInitialAttributesFlagsRequestedByCableMgmt">
+          <event>EVENT_DB_SET_INITIAL_ATTRIBUTES_FLAGS</event>
+          <callback>OnPatchPanelSetInitialAttributesFlagsRequestedByCableMgmt</callback>
           <rank>10</rank>
         </event_listener>
         <event_listener id="OnPatchPanelSetAttributesFlagsRequestedByCableMgmt">

--- a/teemip-cable-mgmt/src/Model/_PatchPanel.php
+++ b/teemip-cable-mgmt/src/Model/_PatchPanel.php
@@ -64,6 +64,18 @@ class _PatchPanel extends PhysicalDevice
 	}
 
 	/**
+     * Set initial attribute flags event on PatchPanel
+     *
+     * @param EventData $oEventData
+     * @return void
+     */
+	public function OnPatchPanelSetInitialAttributesFlagsRequestedByCableMgmt(EventData $oEventData): void
+	{
+        $this->ForceInitialAttributeFlags('free_sockets', OPT_ATT_READONLY);
+        $this->ForceInitialAttributeFlags('ready_sockets', OPT_ATT_READONLY);
+	}
+
+	/**
      * Set attribute flags event on PatchPanel
      *
      * @param EventData $oEventData
@@ -71,8 +83,8 @@ class _PatchPanel extends PhysicalDevice
      */
 	public function OnPatchPanelSetAttributesFlagsRequestedByCableMgmt(EventData $oEventData): void
 	{
-        $this->AddAttributeFlags('free_sockets', OPT_ATT_READONLY);
-        $this->AddAttributeFlags('ready_sockets', OPT_ATT_READONLY);
+        $this->ForceAttributeFlags('free_sockets', OPT_ATT_READONLY);
+        $this->ForceAttributeFlags('ready_sockets', OPT_ATT_READONLY);
 	}
 
 	/**

--- a/teemip-cable-mgmt/src/Model/_PatchPanel.php
+++ b/teemip-cable-mgmt/src/Model/_PatchPanel.php
@@ -71,8 +71,8 @@ class _PatchPanel extends PhysicalDevice
      */
 	public function OnPatchPanelSetInitialAttributesFlagsRequestedByCableMgmt(EventData $oEventData): void
 	{
-        $this->ForceInitialAttributeFlags('free_sockets', OPT_ATT_READONLY);
-        $this->ForceInitialAttributeFlags('ready_sockets', OPT_ATT_READONLY);
+        $this->AddInitialAttributeFlags('free_sockets', OPT_ATT_READONLY);
+        $this->AddInitialAttributeFlags('ready_sockets', OPT_ATT_READONLY);
 	}
 
 	/**
@@ -83,8 +83,8 @@ class _PatchPanel extends PhysicalDevice
      */
 	public function OnPatchPanelSetAttributesFlagsRequestedByCableMgmt(EventData $oEventData): void
 	{
-        $this->ForceAttributeFlags('free_sockets', OPT_ATT_READONLY);
-        $this->ForceAttributeFlags('ready_sockets', OPT_ATT_READONLY);
+        $this->AddAttributeFlags('free_sockets', OPT_ATT_READONLY);
+        $this->AddAttributeFlags('ready_sockets', OPT_ATT_READONLY);
 	}
 
 	/**


### PR DESCRIPTION
In  PatchPanel class

* Set InitialAttributesFlags to `OPT_ATT_READONLY`
* Call `OnPatchPanelComputeValuesRequestedByCableMgmt` after changes of `capacity`